### PR TITLE
エラー発生時、ダイアログを表示して通知するように変更

### DIFF
--- a/nextjs/src/components/context/AlertDialogContextProvider.tsx
+++ b/nextjs/src/components/context/AlertDialogContextProvider.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { AuthContextProviderProps } from './AuthContextProvider';
+import { Dialog, Card, CardHeader, CardContent, Button } from '@mui/material';
+import { AlertDialog } from '../presentational/AlertDialog';
+
+export type AlertDialogProps = {
+    message?: string;
+    description?: string;
+};
+
+export type AlertDialogContext = {
+    open(props: AlertDialogProps): void;
+    close(): void;
+};
+
+export type AlertDialogContextProviderProps = {
+    children: React.ReactNode;
+};
+
+export const AlertDialogContext = React.createContext<AlertDialogContext>({
+    open(props: AlertDialogProps) {},
+    close() {},
+});
+
+export function AlertDialogContextProvider({ children }: AuthContextProviderProps) {
+    const [open, setOpen] = React.useState<boolean>(false);
+    const [dialogProps, setDialogProps] = React.useState<AlertDialogProps>({
+        message: 'エラーが発生しました',
+        description: '',
+    });
+    const handleOpen = React.useCallback(
+        (props: AlertDialogProps) => {
+            setDialogProps({
+                message: props.message || dialogProps.message,
+                description: props.description || dialogProps.description,
+            });
+            setOpen(true);
+        },
+        [dialogProps.description, dialogProps.message]
+    );
+    const handleClose = React.useCallback(() => {
+        setOpen(false);
+    }, []);
+    return (
+        <AlertDialogContext.Provider value={{ open: handleOpen, close: handleClose }}>
+            {children}
+            <AlertDialog
+                message={dialogProps.message}
+                description={dialogProps.description}
+                open={open}
+                onClose={handleClose}
+            />
+        </AlertDialogContext.Provider>
+    );
+}

--- a/nextjs/src/components/context/index.tsx
+++ b/nextjs/src/components/context/index.tsx
@@ -1,3 +1,4 @@
+export * from './AlertDialogContextProvider';
 export * from './AuthContextProvider';
 export * from './EditNewArticleDialogContextProvider';
 export * from './MuiThemeProvider';

--- a/nextjs/src/components/functional/AxiosInterceptorsSettings.tsx
+++ b/nextjs/src/components/functional/AxiosInterceptorsSettings.tsx
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import React from 'react';
 import { AuthContext } from '../context';
+import { AlertDialogContext } from '../context/AlertDialogContextProvider';
 
 export type AxiosInterceptorsSettingsProps = {
     children: React.ReactNode;
@@ -22,17 +23,24 @@ export type AxiosInterceptorsSettingsProps = {
  */
 export function AxiosInterceptorsSettings({ children }: AxiosInterceptorsSettingsProps) {
     const { setUnauthorized } = React.useContext(AuthContext);
+    const { open, close } = React.useContext(AlertDialogContext);
     axios.interceptors.response.use(
         (value: AxiosResponse) => value,
         (error: any) => {
             switch (error.response?.status) {
                 case 401:
                 case 419:
-                    alert('認証エラーが発生しました');
+                case 422:
                     setUnauthorized();
+                    open({
+                        message: '認証エラーが発生しました',
+                        description: '続行するには、再度ログインしてください',
+                    });
             }
             if (!error.response || error.response?.status >= 500) {
-                alert('予期しないエラーが発生しました');
+                open({
+                    message: '予期しないエラーが発生しました',
+                });
             }
             return Promise.reject(error);
         }

--- a/nextjs/src/components/pages/RequireLoginPage.tsx
+++ b/nextjs/src/components/pages/RequireLoginPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
+import { NavBar } from '../container';
 
 export function RequireLoginPage() {
-    return <div>このページの閲覧にはログインが必要です</div>;
+    return <NavBar>このページの閲覧にはログインが必要です</NavBar>;
 }

--- a/nextjs/src/components/presentational/AlertDialog.tsx
+++ b/nextjs/src/components/presentational/AlertDialog.tsx
@@ -1,0 +1,28 @@
+import { Dialog, DialogProps, Card, CardHeader, CardContent, Button } from '@mui/material';
+
+export type AlertDialogProps = {
+    message?: string;
+    description?: string;
+    onClickOk?: React.MouseEventHandler<HTMLButtonElement>;
+} & DialogProps;
+
+export function AlertDialog({
+    message = 'エラーが発生しました',
+    description,
+    onClickOk,
+    ...props
+}: AlertDialogProps) {
+    return (
+        <Dialog {...props}>
+            <Card>
+                <CardHeader title={message} />
+                {description && <CardContent>{description}</CardContent>}
+                <CardContent>
+                    <Button onClick={onClickOk} variant="outlined" fullWidth>
+                        OK
+                    </Button>
+                </CardContent>
+            </Card>
+        </Dialog>
+    );
+}

--- a/nextjs/src/pages/_app.tsx
+++ b/nextjs/src/pages/_app.tsx
@@ -3,7 +3,11 @@ import type { AppProps } from 'next/app';
 import React from 'react';
 import dynamic from 'next/dynamic';
 import axios from 'axios';
-import { AuthContextProvider, EditNewArticleDialogContextProvider } from '../components/context';
+import {
+    AlertDialogContextProvider,
+    AuthContextProvider,
+    EditNewArticleDialogContextProvider,
+} from '../components/context';
 import { AxiosInterceptorsSettings } from '../components/functional';
 import { LoadAuthorization } from '../components/functional/LoadAuthorization';
 
@@ -26,13 +30,15 @@ export default function App({ Component, pageProps }: AppProps) {
     return (
         <AuthContextProvider>
             <PrefersColorSchemeMuiThemeProvider>
-                <EditNewArticleDialogContextProvider>
-                    <AxiosInterceptorsSettings>
-                        <LoadAuthorization>
-                            <Component {...pageProps} />
-                        </LoadAuthorization>
-                    </AxiosInterceptorsSettings>
-                </EditNewArticleDialogContextProvider>
+                <AlertDialogContextProvider>
+                    <EditNewArticleDialogContextProvider>
+                        <AxiosInterceptorsSettings>
+                            <LoadAuthorization>
+                                <Component {...pageProps} />
+                            </LoadAuthorization>
+                        </AxiosInterceptorsSettings>
+                    </EditNewArticleDialogContextProvider>
+                </AlertDialogContextProvider>
             </PrefersColorSchemeMuiThemeProvider>
         </AuthContextProvider>
     );

--- a/nextjs/src/pages/articles/[articleId].tsx
+++ b/nextjs/src/pages/articles/[articleId].tsx
@@ -24,19 +24,19 @@ export default function EditArticlePage() {
                     if (loading)
                         return (
                             <NavBar>
-                                <LoadingPage />
+                                <div>読み込み中...</div>
                             </NavBar>
                         );
                     if (loadResult === null)
                         return (
                             <NavBar>
-                                <ErrorPage errorMessage="article not found" />
+                                <div>記事が見つかりませんでした</div>
                             </NavBar>
                         );
                     if (!(loadResult instanceof Article))
                         return (
                             <NavBar>
-                                <ErrorPage errorMessage={loadResult.id} />
+                                <div>エラーが発生しました</div>
                             </NavBar>
                         );
                     if (editting)

--- a/nextjs/src/pages/articles/index.tsx
+++ b/nextjs/src/pages/articles/index.tsx
@@ -25,8 +25,8 @@ export default function Articles() {
         [router]
     );
     return (
-        <NavBar>
-            <RequireAuthorized>
+        <RequireAuthorized>
+            <NavBar>
                 <Container maxWidth="xl" sx={{ mt: 2 }}>
                     <Container
                         maxWidth="sm"
@@ -80,7 +80,7 @@ export default function Articles() {
                         }}
                     </ArticleListLoader>
                 </Container>
-            </RequireAuthorized>
-        </NavBar>
+            </NavBar>
+        </RequireAuthorized>
     );
 }


### PR DESCRIPTION
Contextで状態と表示/非表示の操作を定義して、
アプリケーション全体で管理できるように

その他、RequireAuthorizedで認証済でない場合に、
NavBar付きのRequireLoginPageを返すようになっているので、
RequireAuthorizedの外にNavBarを配置しないようにする
(NavBarが二重に表示されるため)