### PR TITLE
EditArticleForm周りのリファクタリング

### DIFF
--- a/nextjs/src/components/container/edit-article-form-action-buttons/EditArticleToolBar.tsx
+++ b/nextjs/src/components/container/edit-article-form-action-buttons/EditArticleToolBar.tsx
@@ -1,0 +1,100 @@
+import { AppBar, Toolbar, ToolbarProps, Tooltip } from '@mui/material';
+import React from 'react';
+import Article from '../../../domains/article';
+import { AfterCreateCallback, BeforeCreateCallback } from '../ArticleSaveAsFormDialog';
+import { SaveAsButton } from './SaveAsButton';
+import { AfterSaveCallback, BeforeSaveCallback, SaveButton, SaveButtonProps } from './SaveButton';
+
+/**
+ * ツールバー共通のコールバック
+ * 各アイテムごとのコールバックが呼ばれる前後に共通して呼ばれる
+ */
+export type ToolBarCommonCallbacks = Partial<{
+    before: () => Promise<void>;
+    after: () => Promise<void>;
+}>;
+
+/**
+ * 各アイテムごとのコールバック
+ */
+export type BottomBarActionCallbacks = Partial<{
+    save: Partial<{
+        before: BeforeSaveCallback;
+        after: AfterSaveCallback;
+    }>;
+    create: Partial<{
+        before: BeforeCreateCallback;
+        after: AfterCreateCallback;
+    }>;
+}>;
+
+export type ItemStates = Partial<{
+    [key in 'save' | 'saveAs']: Partial<{ hidden: boolean; disabled: boolean }>;
+}>;
+
+export type EditArticleToolBarProps = {
+    contentTextAreaRef: React.RefObject<HTMLTextAreaElement>;
+    article?: Article;
+    disabled?: boolean;
+    commonCallbacks?: ToolBarCommonCallbacks;
+    itemCallbacks?: BottomBarActionCallbacks;
+    itemStates?: ItemStates;
+} & ToolbarProps;
+
+export const EditArticleToolBar = ({
+    contentTextAreaRef,
+    article,
+    disabled = false,
+    commonCallbacks,
+    itemCallbacks,
+    itemStates,
+    ...props
+}: EditArticleToolBarProps) => {
+    const [open, setOpen] = React.useState<boolean>(false);
+    const handleClose = React.useCallback(() => setOpen(false), []);
+    return (
+        <Toolbar {...props}>
+            {!itemStates?.save?.hidden && (
+                <Tooltip title="上書き保存">
+                    <span>
+                        <SaveButton
+                            article={article}
+                            type="submit"
+                            beforeSaveCallbacks={[
+                                commonCallbacks?.before,
+                                itemCallbacks?.save?.before,
+                            ]}
+                            afterSaveCallbacks={[
+                                itemCallbacks?.save?.after,
+                                commonCallbacks?.after,
+                            ]}
+                            contentTextAreaRef={contentTextAreaRef}
+                            disabled={disabled || itemStates?.save?.disabled}
+                        />
+                    </span>
+                </Tooltip>
+            )}
+            {!itemStates?.saveAs?.hidden && (
+                <Tooltip title="タイトルをつけて保存">
+                    <span>
+                        <SaveAsButton
+                            type="submit"
+                            open={open}
+                            onClose={handleClose}
+                            contentTextAreaRef={contentTextAreaRef}
+                            beforeCreateCallbacks={[
+                                commonCallbacks?.after,
+                                itemCallbacks?.create?.before,
+                            ]}
+                            afterCreateCallbacks={[
+                                itemCallbacks?.create?.after,
+                                commonCallbacks?.after,
+                            ]}
+                            disabled={disabled || itemStates?.saveAs?.disabled}
+                        />
+                    </span>
+                </Tooltip>
+            )}
+        </Toolbar>
+    );
+};

--- a/nextjs/src/components/container/edit-article-form-action-buttons/SaveButton.tsx
+++ b/nextjs/src/components/container/edit-article-form-action-buttons/SaveButton.tsx
@@ -4,33 +4,40 @@ import React from 'react';
 import Article from '../../../domains/article';
 import { UpdateArticleResult, useArticles } from '../../hooks';
 
+export type BeforeSaveCallback = (content?: Article['content']) => Promise<void>;
+export type AfterSaveCallback = (result: UpdateArticleResult) => Promise<void>;
+
 export type SaveButtonProps = {
     article?: Article;
     contentTextAreaRef: React.RefObject<HTMLTextAreaElement>;
-    beforeSaveCallback?(content?: Article['content']): Promise<void>;
-    afterSaveCallback?(result: UpdateArticleResult): Promise<void>;
+    beforeSaveCallbacks?: (BeforeSaveCallback | undefined)[];
+    afterSaveCallbacks?: (AfterSaveCallback | undefined)[];
 } & Omit<IconButtonProps, 'onClick'>;
 
 export function SaveButton({
     article,
     contentTextAreaRef,
-    beforeSaveCallback = async () => {},
-    afterSaveCallback = async () => {},
+    beforeSaveCallbacks = [],
+    afterSaveCallbacks = [],
     ...props
 }: SaveButtonProps) {
     const { update } = useArticles();
     const handleClick = React.useCallback(async () => {
         if (!article) return;
         const content = contentTextAreaRef.current?.value || '';
-        await beforeSaveCallback(content);
+        beforeSaveCallbacks.forEach(async (callback) => {
+            if (callback) await callback(content);
+        });
         const result = await update(
             new Article({
                 ...article,
                 content,
             })
         );
-        await afterSaveCallback(result);
-    }, [afterSaveCallback, article, beforeSaveCallback, contentTextAreaRef, update]);
+        afterSaveCallbacks.forEach(async (callback) => {
+            if (callback) await callback(result);
+        });
+    }, [afterSaveCallbacks, article, beforeSaveCallbacks, contentTextAreaRef, update]);
     return (
         <IconButton onClick={handleClick} {...props} disabled={!article || props.disabled}>
             <Save />

--- a/nextjs/src/components/context/AlertDialogContextProvider.tsx
+++ b/nextjs/src/components/context/AlertDialogContextProvider.tsx
@@ -29,7 +29,7 @@ type State = {
 type Actions =
     | {
           type: 'open';
-          data: AlertDialogProps;
+          payload: AlertDialogProps;
       }
     | {
           type: 'close';
@@ -41,8 +41,8 @@ const reducer = (state: State, action: Actions): State => {
         case 'open':
             return {
                 open: true,
-                message: action.data.message,
-                description: action.data.description,
+                message: action.payload.message,
+                description: action.payload.description,
             };
         case 'close':
             return {
@@ -58,7 +58,7 @@ export function AlertDialogContextProvider({ children }: AuthContextProviderProp
     return (
         <AlertDialogContext.Provider
             value={{
-                open: (props: AlertDialogProps) => dispatch({ type: 'open', data: props }),
+                open: (props: AlertDialogProps) => dispatch({ type: 'open', payload: props }),
                 close: () => dispatch({ type: 'close' }),
             }}
         >

--- a/nextjs/src/components/pages/EditArticleFormPage.tsx
+++ b/nextjs/src/components/pages/EditArticleFormPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@mui/material';
+import { AppBar, Box } from '@mui/material';
 import { CreateArticleResult, UpdateArticleResult } from '../hooks';
 import Article from '../../domains/article';
 import { AuthContext, AuthContextProvider } from '../context';
@@ -44,13 +44,17 @@ export function EditArticleFormPage({ initialMode, initialArticle }: EditArticle
                 >
                     <NavBar>
                         <EditArticleForm
-                            gridContainerProps={{
-                                sx: { flexGrow: 1, overflow: 'hidden' },
-                            }}
+                            sx={{ flexGrow: 1, overflow: 'hidden' }}
                             article={article}
                             mode={currentAuthStatus.isFixedAsAuthorized ? mode : 'unauthorized'}
-                            afterSaveCallback={afterUpdateCallback}
-                            afterCreateCallback={afterCreateCallback}
+                            callbacks={{
+                                save: {
+                                    after: afterUpdateCallback,
+                                },
+                                create: {
+                                    after: afterCreateCallback,
+                                },
+                            }}
                         />
                     </NavBar>
                 </Box>

--- a/nextjs/src/components/pages/ListArticlePage.tsx
+++ b/nextjs/src/components/pages/ListArticlePage.tsx
@@ -26,11 +26,19 @@ export function ListArticlePage({
         },
         [onSubmit]
     );
+    const [articleAreaOffsetY, setArticleAreaOffsetY] = React.useState<number>(0);
+    React.useEffect(() => {
+        const articlesArea = document.getElementById('articles_area');
+        if (articlesArea) {
+            setArticleAreaOffsetY(articlesArea.offsetTop);
+        }
+    }, []);
     return (
         <RequireAuthorized>
             <Box
                 sx={{
                     height: '100vh',
+                    overflow: 'hidden',
                 }}
             >
                 <NavBar>
@@ -57,7 +65,12 @@ export function ListArticlePage({
                                 if (loading || !Array.isArray(result)) return <div>検索中...</div>;
                                 return (
                                     <ArticlesArea
-                                        sx={{ flexGrow: 1 }}
+                                        id="articles_area"
+                                        sx={{
+                                            flexGrow: 1,
+                                            overflow: 'scroll',
+                                            height: `calc(100vh - ${articleAreaOffsetY}px)`,
+                                        }}
                                         articles={result}
                                         onClickArticle={onClickArticle}
                                     />

--- a/nextjs/src/components/presentational/ArticlesArea.tsx
+++ b/nextjs/src/components/presentational/ArticlesArea.tsx
@@ -21,6 +21,7 @@ export function ArticlesArea({
                     {articles.map((article) => (
                         <ListItemButton
                             key={article.id}
+                            onFocus={() => setSelectedArticle(article)}
                             onMouseOver={() => setSelectedArticle(article)}
                             onClick={() => onClickArticle(article)}
                             sx={{ overflow: 'hidden', whiteSpace: 'nowrap' }}


### PR DESCRIPTION
EditArticleForm周りを整理

その他、一覧ページのスタイルを変更
ページ全体ではオーバーフローした分はhiddenにしておいて、
タイトル一覧と内容がそれぞれ個別にスクロールする