### PR TITLE
バグ修正：別ユーザーでログインし直した際、前のユーザーのstateが残る

### DIFF
--- a/nextjs/src/components/pages/AdminPage.tsx
+++ b/nextjs/src/components/pages/AdminPage.tsx
@@ -28,7 +28,7 @@ export function AdminPage() {
         });
     }, [update]);
     return (
-        <RequireAdmin>
+        <>
             {!config ? (
                 <LoadingPage />
             ) : (
@@ -68,6 +68,6 @@ export function AdminPage() {
                     </FormWithSubmittingState>
                 </NavBar>
             )}
-        </RequireAdmin>
+        </>
     );
 }

--- a/nextjs/src/components/pages/ListArticlePage.tsx
+++ b/nextjs/src/components/pages/ListArticlePage.tsx
@@ -221,33 +221,31 @@ export function ListArticlePage({
         [state.featuredArticle, state.fixedArticle]
     );
     return (
-        <RequireAuthorized>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    height: '100vh',
-                    overflow: 'hidden',
-                }}
-            >
-                <NavBar>
-                    <Grid
-                        id="article-area"
-                        container
-                        spacing={1}
-                        sx={{ height: `calc(100% - ${state.articleAreaOffsetY}px)` }}
-                    >
-                        <Grid xs={4} item sx={{ height: '100%', overflow: 'scroll' }}>
-                            {DeleteArticleButtonMemo}
-                            {ListMemo}
-                            {PaginationMemo}
-                        </Grid>
-                        <Grid xs={8} item sx={{ height: '100%', overflow: 'scroll' }}>
-                            {ArticleMarkdownMemo}
-                        </Grid>
+        <Box
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                height: '100vh',
+                overflow: 'hidden',
+            }}
+        >
+            <NavBar>
+                <Grid
+                    id="article-area"
+                    container
+                    spacing={1}
+                    sx={{ height: `calc(100% - ${state.articleAreaOffsetY}px)` }}
+                >
+                    <Grid xs={4} item sx={{ height: '100%', overflow: 'scroll' }}>
+                        {DeleteArticleButtonMemo}
+                        {ListMemo}
+                        {PaginationMemo}
                     </Grid>
-                </NavBar>
-            </Box>
-        </RequireAuthorized>
+                    <Grid xs={8} item sx={{ height: '100%', overflow: 'scroll' }}>
+                        {ArticleMarkdownMemo}
+                    </Grid>
+                </Grid>
+            </NavBar>
+        </Box>
     );
 }

--- a/nextjs/src/components/pages/ShowArticlePage.tsx
+++ b/nextjs/src/components/pages/ShowArticlePage.tsx
@@ -17,47 +17,45 @@ export function ShowArticlePage({ articleId }: ShowArticlePageProps) {
         setEditting(true);
     }, []);
     return (
-        <RequireAuthorized>
-            <ArticleLoader id={articleId}>
-                {(loading, loadResult) => {
-                    if (loadResult?.isSuccess && editting)
-                        return (
-                            <EditArticleFormPage
-                                initialArticle={loadResult.data}
-                                initialMode="update"
-                            />
-                        );
+        <ArticleLoader id={articleId}>
+            {(loading, loadResult) => {
+                if (loadResult?.isSuccess && editting)
                     return (
-                        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-                            <NavBar>
-                                <Grid
-                                    container
-                                    sx={{ flexGrow: 1, overflow: 'hidden', height: '100%' }}
-                                >
-                                    <Grid item xs={2} sx={{ height: '100%' }}>
-                                        <List>
-                                            <ListItemButton
-                                                onClick={handleStartEdit}
-                                                disabled={loading}
-                                            >
-                                                <Edit />
-                                                編集
-                                            </ListItemButton>
-                                        </List>
-                                    </Grid>
-                                    <Grid item xs={8} sx={{ height: '100%', overflow: 'scroll' }}>
-                                        {loading && <div>読み込み中...</div>}
-                                        {loadResult?.isSuccess && (
-                                            <ArticleMarkdown article={loadResult.data} />
-                                        )}
-                                    </Grid>
-                                    <Grid item xs={2}></Grid>
-                                </Grid>
-                            </NavBar>
-                        </Box>
+                        <EditArticleFormPage
+                            initialArticle={loadResult.data}
+                            initialMode="update"
+                        />
                     );
-                }}
-            </ArticleLoader>
-        </RequireAuthorized>
+                return (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+                        <NavBar>
+                            <Grid
+                                container
+                                sx={{ flexGrow: 1, overflow: 'hidden', height: '100%' }}
+                            >
+                                <Grid item xs={2} sx={{ height: '100%' }}>
+                                    <List>
+                                        <ListItemButton
+                                            onClick={handleStartEdit}
+                                            disabled={loading}
+                                        >
+                                            <Edit />
+                                            編集
+                                        </ListItemButton>
+                                    </List>
+                                </Grid>
+                                <Grid item xs={8} sx={{ height: '100%', overflow: 'scroll' }}>
+                                    {loading && <div>読み込み中...</div>}
+                                    {loadResult?.isSuccess && (
+                                        <ArticleMarkdown article={loadResult.data} />
+                                    )}
+                                </Grid>
+                                <Grid item xs={2}></Grid>
+                            </Grid>
+                        </NavBar>
+                    </Box>
+                );
+            }}
+        </ArticleLoader>
     );
 }

--- a/nextjs/src/pages/admin/index.tsx
+++ b/nextjs/src/pages/admin/index.tsx
@@ -1,5 +1,10 @@
+import { RequireAdmin } from '../../components/container/RequireAdmin';
 import { AdminPage } from '../../components/pages/AdminPage';
 
 export default function Admin() {
-    return <AdminPage />;
+    return (
+        <RequireAdmin>
+            <AdminPage />
+        </RequireAdmin>
+    );
 }

--- a/nextjs/src/pages/articles/[articleId]/index.tsx
+++ b/nextjs/src/pages/articles/[articleId]/index.tsx
@@ -1,12 +1,15 @@
 import { useRouter } from 'next/router';
+import { RequireAuthorized } from '../../../components/container';
 import { ShowErrorPageIfArticleIdIsInvalid } from '../../../components/functional/ShowErrorPageIfArticleIdIsInvalid';
 import { ShowArticlePage } from '../../../components/pages/ShowArticlePage';
 
 export default function ShowArticle() {
     const { articleId } = useRouter().query;
     return (
-        <ShowErrorPageIfArticleIdIsInvalid articleId={articleId}>
-            {(validArticleId) => <ShowArticlePage articleId={validArticleId} />}
-        </ShowErrorPageIfArticleIdIsInvalid>
+        <RequireAuthorized>
+            <ShowErrorPageIfArticleIdIsInvalid articleId={articleId}>
+                {(validArticleId) => <ShowArticlePage articleId={validArticleId} />}
+            </ShowErrorPageIfArticleIdIsInvalid>
+        </RequireAuthorized>
     );
 }

--- a/nextjs/src/pages/articles/index.tsx
+++ b/nextjs/src/pages/articles/index.tsx
@@ -6,6 +6,7 @@ import {
     ProvideParams,
 } from '../../components/functional/ListArticlePageWrapper';
 import Article from '../../domains/article';
+import { RequireAuthorized } from '../../components/container';
 
 const parseQueryItemToNumber = (queryItem: string | string[] | undefined, defaultValue = 0) => {
     return Number.isNaN(Number(queryItem)) ? defaultValue : Number(queryItem);
@@ -30,18 +31,20 @@ export default function Articles() {
         ),
     ];
     return (
-        <ListArticlePageWrapper q={q} page={page}>
-            {({ articles, page, pageCount, loading, afterDeleteCallback }: ProvideParams) => (
-                <ListArticlePage
-                    articles={articles}
-                    page={page}
-                    pageCount={pageCount}
-                    disabled={loading}
-                    afterDeleteCallback={afterDeleteCallback}
-                    onEditArticle={onEditArticle}
-                    onChangePage={onChangePage}
-                />
-            )}
-        </ListArticlePageWrapper>
+        <RequireAuthorized>
+            <ListArticlePageWrapper q={q} page={page}>
+                {({ articles, page, pageCount, loading, afterDeleteCallback }: ProvideParams) => (
+                    <ListArticlePage
+                        articles={articles}
+                        page={page}
+                        pageCount={pageCount}
+                        disabled={loading}
+                        afterDeleteCallback={afterDeleteCallback}
+                        onEditArticle={onEditArticle}
+                        onChangePage={onChangePage}
+                    />
+                )}
+            </ListArticlePageWrapper>
+        </RequireAuthorized>
     );
 }


### PR DESCRIPTION
1. ログイン
2. 記事一覧画面/記事編集画面を開く
3. ログアウト
4. 別ユーザーでログイン

上記手順で、別ユーザーでログインする前に表示されていた記事が別ユーザーでログイン時にも残ってしまっていた。 useEffectなどで記事を取得しているコンポーネントが、ログインし直した際に再描画されないため発生。

RequireAuthorized, RequireAdminを/components/pagesでなく/pagesに置くことで、 AuthStatusが変わった場合に/components/pagesを描画し直すように修正

以後、RequireAuthorized, RequireAdminは/pagesの方に置くようにする