### PR TITLE
タグ検索機能の実装

### DIFF
--- a/nextjs/src/components/functional/ListArticlePageWrapper.tsx
+++ b/nextjs/src/components/functional/ListArticlePageWrapper.tsx
@@ -69,7 +69,7 @@ const initialState: State = {
  *     1. ListArticlePageに渡すarticlesを読み込み直す
  *     2. articlesのチェック状態はリセットする
  */
-export function ListArticlePageWrapper({ children, q, page }: ListArticlePageWrapperProps) {
+export function ListArticlePageWrapper({ children, tagIds, q, page }: ListArticlePageWrapperProps) {
     const [state, dispatch] = React.useReducer(reducer, initialState);
     const { list } = useArticles();
     const loadList = React.useCallback(() => {
@@ -80,6 +80,7 @@ export function ListArticlePageWrapper({ children, q, page }: ListArticlePageWra
         list({
             q,
             page,
+            tagIds,
         })
             .then((listResult) => {
                 if (!listResult.isSuccess) {
@@ -99,7 +100,7 @@ export function ListArticlePageWrapper({ children, q, page }: ListArticlePageWra
                     payload: false,
                 });
             });
-    }, [list, page, q]);
+    }, [list, page, q, tagIds]);
     const afterDeleteCallback: ListArticlePageProps['afterDeleteCallback'] = React.useCallback(
         async (result: DestroyArticleResult, currentCheckedArticles) => {
             if (!result.isSuccess) {

--- a/nextjs/src/components/hooks/articles.ts
+++ b/nextjs/src/components/hooks/articles.ts
@@ -13,6 +13,7 @@ export type CreateArticleResult = ApiResponse<Article, InputError<CreateArticleP
 
 // list
 export type ListArticleParams = {
+    tagIds?: string[];
     q?: string;
     page?: number;
 };
@@ -102,10 +103,13 @@ export function useArticles(): UseArticleFunctions {
     }, []);
     const { restartProcess, clearAbortSignal } = useAbortController();
     const list = React.useCallback(
-        async ({ q = '', page = 1 }: ListArticleParams) => {
+        async ({ tagIds = [], q = '', page = 1 }: ListArticleParams) => {
+            const tagIdParams = tagIds
+                .map((tagId, index) => `tag_ids[${index}]=${tagId}`)
+                .join('&');
             const signal = restartProcess();
             const result: ListArticleResult = await axios
-                .get(`/api/articles?q=${q}&page=${page}`, {
+                .get(`/api/articles?q=${q}&page=${page}&${tagIdParams}`, {
                     signal,
                 })
                 .then((res: AxiosResponse) => {

--- a/nextjs/src/components/pages/CreateArticlePage.tsx
+++ b/nextjs/src/components/pages/CreateArticlePage.tsx
@@ -1,4 +1,4 @@
-import { ArticleTagsLoader } from '../functional/ArticleTagsLoader';
+import { AuthContext } from '../context';
 import { EditArticleFormPage } from './EditArticleFormPage';
 import { ErrorPage } from './ErrorPage';
 import { LoadingPage } from './LoadingPage';
@@ -7,15 +7,8 @@ export type CreateArticlePageProps = {};
 
 export function CreateArticlePage({}: CreateArticlePageProps) {
     return (
-        <ArticleTagsLoader>
-            {(_, result) => {
-                return (
-                    <EditArticleFormPage
-                        initialMode="create"
-                        tagOptions={result?.isSuccess ? result.data : []}
-                    />
-                );
-            }}
-        </ArticleTagsLoader>
+        <AuthContext.Consumer>
+            {({ tags }) => <EditArticleFormPage initialMode="create" tagOptions={tags} />}
+        </AuthContext.Consumer>
     );
 }

--- a/nextjs/src/components/presentational/ArticleSearchForm/SearchByTags.tsx
+++ b/nextjs/src/components/presentational/ArticleSearchForm/SearchByTags.tsx
@@ -1,0 +1,65 @@
+import { Search } from '@mui/icons-material';
+import {
+    Autocomplete,
+    AutocompleteProps,
+    IconButton,
+    InputAdornment,
+    SxProps,
+    TextField,
+} from '@mui/material';
+import React from 'react';
+import ArticleTag from '../../../domains/article-tag';
+import { FormWithSubmittingState, FormWithSubmittingStateProps } from '../FormWithSubmittingState';
+
+export type SearchByTagsProps = {
+    onSubmit(value?: ArticleTag[]): Promise<void>;
+    tagOptions: ArticleTag[];
+    sx?: SxProps;
+} & Omit<FormWithSubmittingStateProps, 'onSubmit'>;
+
+export function SearchByTags({ onSubmit, tagOptions, sx }: SearchByTagsProps) {
+    const [currentTags, setCurrentTags] = React.useState<ArticleTag[]>([]);
+    const handleSubmit = React.useCallback(() => onSubmit(currentTags), [currentTags, onSubmit]);
+    return (
+        <FormWithSubmittingState onSubmit={handleSubmit}>
+            {(submitting) => (
+                <Autocomplete
+                    multiple
+                    disabled={submitting}
+                    value={currentTags}
+                    isOptionEqualToValue={(option, value) => {
+                        return option.id === value.id;
+                    }}
+                    sx={sx}
+                    options={tagOptions}
+                    getOptionLabel={(option) => option.name}
+                    disableClearable
+                    forcePopupIcon={false}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            InputProps={{
+                                ...params.InputProps,
+                                endAdornment: (
+                                    <InputAdornment
+                                        disablePointerEvents={submitting}
+                                        position="end"
+                                    >
+                                        <IconButton type="submit">
+                                            <Search />
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            }}
+                            fullWidth
+                            placeholder="タグで検索"
+                            variant="outlined"
+                            disabled={submitting}
+                        />
+                    )}
+                    onChange={(_, values) => setCurrentTags(values)}
+                />
+            )}
+        </FormWithSubmittingState>
+    );
+}

--- a/nextjs/src/components/presentational/ArticleSearchForm/SearchByTitleOrContent.tsx
+++ b/nextjs/src/components/presentational/ArticleSearchForm/SearchByTitleOrContent.tsx
@@ -1,38 +1,36 @@
 import { Search } from '@mui/icons-material';
 import { IconButton, InputAdornment, TextField, TextFieldProps } from '@mui/material';
 import React from 'react';
-import { ListArticleParams, ListArticleResult, useArticles } from '../hooks';
-import { FormWithSubmittingState, FormWithSubmittingStateProps } from '../presentational';
-import { ArticleSearchFormComponentProps } from '../presentational/ArticleSearchFormComponent';
+import { FormWithSubmittingState, FormWithSubmittingStateProps } from '../FormWithSubmittingState';
 
-export type ArticleListSearchFormProps = {
-    onSubmit(result: ListArticleResult): Promise<void>;
-    page?: number;
-} & Omit<ArticleSearchFormComponentProps<'titleOrContent'>, 'onSubmit'>;
+type SearchByTitleOrContentComponentProps = Omit<
+    TextFieldProps,
+    'InputProps' | 'placeholder' | 'inputRef' | 'onSubmit'
+>;
 
-export function ArticleListSearchForm({
+export type SearchByTitleOrContentProps = {
+    onSubmit(value?: string): Promise<void>;
+    componentProps?: SearchByTitleOrContentComponentProps;
+} & Omit<FormWithSubmittingStateProps, 'onSubmit'>;
+
+export function SearchByTitleOrContent({
     onSubmit,
-    page,
     componentProps,
     ...props
-}: ArticleListSearchFormProps) {
-    const { list } = useArticles();
+}: SearchByTitleOrContentProps) {
     const searchFieldInputRef = React.useRef<HTMLInputElement>(null);
     const handleSubmit = React.useCallback(
         async (e: React.FormEvent<HTMLFormElement>) => {
             e.preventDefault();
-            const searchResult = await list({
-                q: searchFieldInputRef.current?.value,
-                page,
-            });
-            await onSubmit(searchResult);
+            await onSubmit(searchFieldInputRef.current?.value);
         },
-        [list, onSubmit, page]
+        [onSubmit]
     );
     return (
         <FormWithSubmittingState onSubmit={handleSubmit} {...props}>
             {(submitting) => (
                 <TextField
+                    {...componentProps}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment disablePointerEvents={submitting} position="end">
@@ -42,10 +40,9 @@ export function ArticleListSearchForm({
                             </InputAdornment>
                         ),
                     }}
-                    disabled={submitting}
-                    placeholder="タイトル,内容で検索"
+                    disabled={componentProps?.disabled || submitting}
+                    placeholder="タイトル、内容で検索"
                     inputRef={searchFieldInputRef}
-                    {...componentProps}
                 />
             )}
         </FormWithSubmittingState>

--- a/nextjs/src/components/presentational/ArticleSearchFormComponent.tsx
+++ b/nextjs/src/components/presentational/ArticleSearchFormComponent.tsx
@@ -1,45 +1,40 @@
-import { Search } from '@mui/icons-material';
-import { IconButton, InputAdornment, TextField, TextFieldProps } from '@mui/material';
 import React from 'react';
-import { FormWithSubmittingState, FormWithSubmittingStateProps } from './FormWithSubmittingState';
+import { SearchByTags, SearchByTagsProps } from './ArticleSearchForm/SearchByTags';
+import {
+    SearchByTitleOrContent,
+    SearchByTitleOrContentProps,
+} from './ArticleSearchForm/SearchByTitleOrContent';
+import { FormWithSubmittingStateProps } from './FormWithSubmittingState';
 
-export type ArticleSearchFormComponentProps = {
-    onSubmit(value?: string): Promise<void>;
-    textFieldProps?: Omit<TextFieldProps, 'InputProps' | 'placeholder' | 'inputRef' | 'onSubmit'>;
-} & Omit<FormWithSubmittingStateProps, 'onSubmit'>;
+export type SearchBy = 'titleOrContent' | 'tags';
 
-export function ArticleSearchFormComponent({
-    onSubmit,
-    textFieldProps,
-    ...props
-}: ArticleSearchFormComponentProps) {
-    const searchFieldInputRef = React.useRef<HTMLInputElement>(null);
-    const handleSubmit = React.useCallback(
-        async (e: React.FormEvent<HTMLFormElement>) => {
-            e.preventDefault();
-            await onSubmit(searchFieldInputRef.current?.value);
-        },
-        [onSubmit]
-    );
-    return (
-        <FormWithSubmittingState onSubmit={handleSubmit} {...props}>
-            {(submitting) => (
-                <TextField
-                    {...textFieldProps}
-                    InputProps={{
-                        endAdornment: (
-                            <InputAdornment disablePointerEvents={submitting} position="end">
-                                <IconButton type="submit">
-                                    <Search />
-                                </IconButton>
-                            </InputAdornment>
-                        ),
-                    }}
-                    disabled={textFieldProps?.disabled || submitting}
-                    placeholder="タイトル、内容で検索"
-                    inputRef={searchFieldInputRef}
-                />
-            )}
-        </FormWithSubmittingState>
-    );
+export type ArticleSearchFormComponentProps<T extends SearchBy> = {
+    searchBy: T;
+} & (T extends 'titleOrContent' ? SearchByTitleOrContentProps : {}) &
+    (T extends 'tags' ? SearchByTagsProps : {}) &
+    Omit<FormWithSubmittingStateProps, 'onSubmit'>;
+
+export function ArticleSearchFormComponent<T extends SearchBy>(
+    props: ArticleSearchFormComponentProps<T>
+) {
+    if (props.searchBy === 'titleOrContent') {
+        const titleOrContentProps = props as ArticleSearchFormComponentProps<'titleOrContent'>;
+        return (
+            <SearchByTitleOrContent
+                onSubmit={titleOrContentProps.onSubmit}
+                componentProps={titleOrContentProps.componentProps}
+            />
+        );
+    }
+    if (props.searchBy === 'tags') {
+        const tagsProps = props as ArticleSearchFormComponentProps<'tags'>;
+        return (
+            <SearchByTags
+                onSubmit={tagsProps.onSubmit}
+                tagOptions={tagsProps.tagOptions}
+                sx={tagsProps.sx}
+            />
+        );
+    }
+    return <></>;
 }

--- a/nextjs/src/pages/articles/[articleId]/edit.tsx
+++ b/nextjs/src/pages/articles/[articleId]/edit.tsx
@@ -5,6 +5,8 @@ import { LoadingPage } from '../../../components/pages';
 import { ErrorPage } from '../../../components/pages/ErrorPage';
 import { RequireAuthorized } from '../../../components/container';
 import { ArticleEditParamsLoader } from '../../../components/functional/loaders/ArticleEditParamsLoader';
+import { ArticleLoader } from '../../../components/functional/loaders/ArticleLoader';
+import { AuthContext } from '../../../components/context';
 
 export default function EditArticle() {
     const { articleId } = useRouter().query;
@@ -12,20 +14,23 @@ export default function EditArticle() {
         <RequireAuthorized>
             <ShowErrorPageIfArticleIdIsInvalid articleId={articleId}>
                 {(validArticleId) => (
-                    <ArticleEditParamsLoader id={validArticleId}>
-                        {(loading, loadResult) => {
-                            if (loading) return <LoadingPage />;
-                            if (!loadResult?.article.isSuccess || !loadResult.tags.isSuccess)
-                                return <ErrorPage />;
-                            return (
-                                <EditArticleFormPage
-                                    initialArticle={loadResult.article.data}
-                                    initialMode="update"
-                                    tagOptions={loadResult.tags.data}
-                                />
-                            );
-                        }}
-                    </ArticleEditParamsLoader>
+                    <AuthContext.Consumer>
+                        {({ tags }) => (
+                            <ArticleLoader id={validArticleId}>
+                                {(loading, loadResult) => {
+                                    if (loading) return <LoadingPage />;
+                                    if (!loadResult?.isSuccess) return <ErrorPage />;
+                                    return (
+                                        <EditArticleFormPage
+                                            initialArticle={loadResult.data}
+                                            initialMode="update"
+                                            tagOptions={tags}
+                                        />
+                                    );
+                                }}
+                            </ArticleLoader>
+                        )}
+                    </AuthContext.Consumer>
                 )}
             </ShowErrorPageIfArticleIdIsInvalid>
         </RequireAuthorized>

--- a/nextjs/src/pages/articles/index.tsx
+++ b/nextjs/src/pages/articles/index.tsx
@@ -12,10 +12,16 @@ const parseQueryItemToNumber = (queryItem: string | string[] | undefined, defaul
     return Number.isNaN(Number(queryItem)) ? defaultValue : Number(queryItem);
 };
 
+const parseQueryItemToStringArray = (queryItem?: string | string[]): string[] => {
+    if (!queryItem) return [];
+    return typeof queryItem === 'string' ? [queryItem] : queryItem;
+};
+
 export default function Articles() {
     const router = useRouter();
     const q = router.query['q'] as string;
     const page = parseQueryItemToNumber(router.query['page'], 1);
+    const tagIds = parseQueryItemToStringArray(router.query['tag_ids']);
     const [onEditArticle, onChangePage] = [
         React.useCallback(
             async (article: Article) => {
@@ -25,14 +31,16 @@ export default function Articles() {
         ),
         React.useCallback(
             async (page: number) => {
-                router.push(`/articles?q=${q || ''}&page=${page}`);
+                const newQ = q || '';
+                const newTagIds = tagIds.map((tagId) => `tag_ids=${tagId}`).join('&');
+                router.push(`/articles?q=${newQ}&page=${page}&${newTagIds}`);
             },
-            [q, router]
+            [q, router, tagIds]
         ),
     ];
     return (
         <RequireAuthorized>
-            <ListArticlePageWrapper q={q} page={page}>
+            <ListArticlePageWrapper tagIds={tagIds} q={q} page={page}>
                 {({ articles, page, pageCount, loading, afterDeleteCallback }: ProvideParams) => (
                     <ListArticlePage
                         articles={articles}


### PR DESCRIPTION
- ナビゲーションバーにタグ検索フォームの切り替えスイッチを配置
- スイッチがONの時、タグ検索が可能になる
- タグ検索は、複数のタグで入力可能。入力したタグのOR検索になる
- タグ検索での選択肢を取得するため、ログイン時にタグ一覧を取得
- ログイン/ログアウトでタグ一覧のリロードを行いたいので、タグ一覧をAuthContextに配置